### PR TITLE
pip install -r requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Si-Yuan Cao, Jianxin Hu, ZeHua Sheng, Hui-Liang Shen
 - [Acknowledgement](#acknowledgement)
 
 ## Requirements
-- Create a new anaconda environment and install all required packages before running the code.
+- Create a new anaconda environment (python 3.8) and install all required packages before running the code.
 ```
 conda create --name ihn
 conda activate ihn
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
 ## Usage


### PR DESCRIPTION
pip install requirements.txt  -->  HINT: You are attempting to install a package literally named "requirements.txt" (which cannot exist). Consider using the '-r' flag to install the packages listed in requirements.txt

For python 3.9, 3.10, 3.11  -->  ERROR: Could not find a version that satisfies the requirement